### PR TITLE
Fix for broken migration

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -10,13 +10,15 @@ Redmine::Plugin.register :redmine_ultraviolet do
   version "0.0.3"
 
   # Create a dropdown list in the UI so the user can pick a theme.
-  unless UserCustomField.find_by_name('Ultraviolet Theme')
-    UserCustomField.create(
-      :name             => 'Ultraviolet Theme', 
-      :default_value    => Uv::DEFAULT_THEME, 
-      :possible_values  => Uv::THEMES,  # see ultraviolet_syntax_patch.rb
-      :field_format     => 'list',
-      :is_required      => true
-    )
+  if UserCustomField.table_exists?
+    unless UserCustomField.find_by_name('Ultraviolet Theme')
+      UserCustomField.create(
+        :name             => 'Ultraviolet Theme', 
+        :default_value    => Uv::DEFAULT_THEME, 
+        :possible_values  => Uv::THEMES,  # see   ultraviolet_syntax_patch.rb
+        :field_format     => 'list',
+        :is_required      => true
+      )
+    end
   end
 end

--- a/init.rb
+++ b/init.rb
@@ -10,13 +10,15 @@ Redmine::Plugin.register :redmine_ultraviolet do
   version "0.0.3"
 
   # Create a dropdown list in the UI so the user can pick a theme.
-  unless UserCustomField.find_by_name('Ultraviolet Theme')
-    UserCustomField.create(
-      :name             => 'Ultraviolet Theme', 
-      :default_value    => Uv::DEFAULT_THEME, 
-      :possible_values  => Uv::THEMES,  # see ultraviolet_syntax_patch.rb
-      :field_format     => 'list',
-      :is_required      => true
-    )
+  if UserCustomField.table_exists?
+    unless UserCustomField.find_by_name('Ultraviolet Theme')
+      UserCustomField.create(
+	:name             => 'Ultraviolet Theme', 
+	:default_value    => Uv::DEFAULT_THEME, 
+	:possible_values  => Uv::THEMES,  # see ultraviolet_syntax_patch.rb
+	:field_format     => 'list',
+	:is_required      => true
+      )
+    end
   end
 end

--- a/init.rb
+++ b/init.rb
@@ -10,15 +10,13 @@ Redmine::Plugin.register :redmine_ultraviolet do
   version "0.0.3"
 
   # Create a dropdown list in the UI so the user can pick a theme.
-  if UserCustomField.table_exists?
-    unless UserCustomField.find_by_name('Ultraviolet Theme')
-      UserCustomField.create(
-	:name             => 'Ultraviolet Theme', 
-	:default_value    => Uv::DEFAULT_THEME, 
-	:possible_values  => Uv::THEMES,  # see ultraviolet_syntax_patch.rb
-	:field_format     => 'list',
-	:is_required      => true
-      )
-    end
+  unless UserCustomField.find_by_name('Ultraviolet Theme')
+    UserCustomField.create(
+      :name             => 'Ultraviolet Theme', 
+      :default_value    => Uv::DEFAULT_THEME, 
+      :possible_values  => Uv::THEMES,  # see ultraviolet_syntax_patch.rb
+      :field_format     => 'list',
+      :is_required      => true
+    )
   end
 end


### PR DESCRIPTION
Since redmine_ultraviolet doesn't check for the existence of the UserCustomValues table in init migration is broken. This fixes it.
