### PR TITLE
Readme improvement for OSX

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -10,7 +10,12 @@ language under the sun. And it has lots of themes!
 
 First, install Ultraviolet:
 
-  apt-get install libonig-dev
+  apt-get install libonig-dev 
+
+Or for OSX using HomeBrew:
+
+  brew install oniguruma
+
   gem install ultraviolet
 
 Next, use Rails' handy-dandy plugin installer to grab this plugin:


### PR DESCRIPTION
Added a section on installing oniguruma for OSX using http://mxcl.github.com/homebrew/.  Felt this was necessary because the library name is quite different to what you've shown and it took me some time to track this down.
